### PR TITLE
change default auth method for documentation on developer.bcc.no to bcc-login

### DIFF
--- a/.github/workflows/build-and-deploy-documentation.yml
+++ b/.github/workflows/build-and-deploy-documentation.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           title: Documentation Guide
           description: Information on how to set up documentation for BCC projects
+          authentication: 'portal'


### PR DESCRIPTION
change default auth method for documentation on developer.bcc.no to bcc-login